### PR TITLE
Remove page prefix from PNG filenames

### DIFF
--- a/Static/Python/GeneratePDF.py
+++ b/Static/Python/GeneratePDF.py
@@ -192,7 +192,10 @@ class PlantPDF(FPDF):
         self.ln(2)
 
         # ── Images ──
-        images = sorted(list(IMG_DIR.glob(f"*_{base_name}_*.jpg")) + list(IMG_DIR.glob(f"*_{base_name}_*.png")))    # Find up to 3 images
+        images = sorted(
+            list(IMG_DIR.glob(f"{base_name}_*.jpg"))
+            + list(IMG_DIR.glob(f"{base_name}_*.png"))
+        )  # Find up to 3 images
         count = max(1, min(len(images), 3))
         margin = self.l_margin
         avail_w = self.w - margin - self.r_margin
@@ -333,8 +336,8 @@ def try_image_path(base_dir, filenames):
             return path
     return None
 
-left_logo = try_image_path(logo_dir, ["001_rutgers_cooperative_extension_1.jpg", "001_rutgers_cooperative_extension_1.png"])
-right_logo = try_image_path(logo_dir, ["001_rutgers_cooperative_extension_2.jpg", "001_rutgers_cooperative_extension_2.png"])
+left_logo = try_image_path(logo_dir, ["rutgers_cooperative_extension_0.jpg", "rutgers_cooperative_extension_0.png"])
+right_logo = try_image_path(logo_dir, ["rutgers_cooperative_extension_1.jpg", "rutgers_cooperative_extension_1.png"])
 if left_logo:
     pdf.image(str(left_logo), x=pdf.l_margin, y=20, h=30)
 if right_logo:

--- a/Static/Python/PDFScraper.py
+++ b/Static/Python/PDFScraper.py
@@ -200,8 +200,8 @@ def extract_images(df: pd.DataFrame) -> None:
         for img_index, img in enumerate(images, start=1):
             xref = img[0]
             pix = fitz.Pixmap(doc, xref)
-            count = page_image_count[base_name] + 1
-            filename = f"{page_index:03d}_{base_name}_{count}.png"
+            count = page_image_count[base_name]
+            filename = f"{base_name}_{count}.png"
             output_path = IMG_DIR / filename
             if pix.n < 5:
                 pix.save(output_path)

--- a/TEst.py
+++ b/TEst.py
@@ -235,8 +235,8 @@ def extract_images(df: pd.DataFrame) -> None:
         for img_index, img in enumerate(images, start=1):
             xref = img[0]
             pix  = fitz.Pixmap(doc, xref)
-            count = page_image_count[base_name] + 1
-            filename = f"{page_index:03d}_{base_name}_{count}.png"
+            count = page_image_count[base_name]
+            filename = f"{base_name}_{count}.png"
             output_path = IMG_DIR / filename
             if pix.n < 5:
                 pix.save(output_path)

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ pip install -r requirements.txt
 ## 🔧 Notes
 
 * Chrome/Selenium requires a portable installation of Chrome.
-* Image filenames use: `page#_botanical_slug_count.jpg`.
+* Image filenames use: `botanical_slug_index.jpg` starting at 0.
 * PDF sections auto-group by type (Herbaceous, Ferns, Shrubs, etc).
 * `Excelify2.py` sets filters on select columns and highlights missing values.
 * Scripts are designed to be rerun with override support.


### PR DESCRIPTION
## Summary
- export images without PDF page prefix
- match new image filenames in PDF generator
- update README documentation

## Testing
- `python -m py_compile Static/Python/PDFScraper.py TEst.py Static/Python/GeneratePDF.py`
- `black --check .` *(fails: would reformat 9 files)*


------
https://chatgpt.com/codex/tasks/task_e_68407860a7f08326824d43abced8c294