### PR TITLE
Improve GetLinks fallback search

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ pip install -r requirements.txt
 
 ### `GetLinks.py`
 
-* Uses Selenium (with Bing and HTML fallback) to find links for Missouri Botanical Garden, Wildflower.org, Pleasant Run Nursery, New Moon Nursery, and Pinelands Nursery.
+* Uses each site's search first, then falls back to Bing with Selenium (HTML fallback).
 * Requires portable Chrome setup.
 * Outputs `Plants_Linked.csv`.
 


### PR DESCRIPTION
## Summary
- add direct HTML search helpers for Pleasant Run, New Moon, and Pinelands
- call these helpers before declaring links not found
- describe the new search order in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68408082a0108326b965af843b187664