### PR TITLE
Fix Pinelands fallback link

### DIFF
--- a/Static/Python/GetLinks.py
+++ b/Static/Python/GetLinks.py
@@ -250,6 +250,9 @@ def query_pn_html(name: str) -> Optional[str]:
                     if isinstance(item, dict) and item.get("@type") == "Product" and item.get("url"):
                         return item["url"]
 
+        # if no direct product link found, return the search page itself
+        return url
+
 # ─── Search only rows that still need links ─────────────────────────────
 for i, row in needs.iterrows():
     bname = row["Botanical Name"]


### PR DESCRIPTION
## Summary
- return the search results page if Pinelands product page is missing

## Testing
- `python -m py_compile Static/Python/GetLinks.py`
- `python - <<'PY'
import json, requests
from bs4 import BeautifulSoup
from urllib.parse import quote_plus
HEADERS={"User-Agent":"Mozilla/5.0"}

def safe_get(url,retries=2,delay=2):
 import time
 for _ in range(retries+1):
  try:
   r=requests.get(url,headers=HEADERS,timeout=10)
   if r.ok:
    return r
  except Exception:
   pass
  time.sleep(delay)

def query_pn_html(name:str):
 url=f"https://www.pinelandsnursery.com/search?query={quote_plus(name)}"
 if r:=safe_get(url):
  soup=BeautifulSoup(r.text,'lxml')
  a=soup.select_one("div.product-name a[href^='https://www.pinelandsnursery.com/']")
  if a and a.get('href'):
   return a['href']
  for script in soup.select("script[type='application/ld+json']"):
   try:
    data=json.loads(script.string)
   except Exception:
    continue
   if isinstance(data,dict) and data.get('@type')=='Product' and data.get('url'):
    return data['url']
   if isinstance(data,list):
    for item in data:
     if isinstance(item,dict) and item.get('@type')=='Product' and item.get('url'):
      return item['url']
  return url

print(query_pn_html('Asclepias incarnata'))
print(query_pn_html('someunknownplantthatdoesntexist'))
PY

------
https://chatgpt.com/codex/tasks/task_e_684087059f188326909a2ef34bb8ff98