### PR TITLE
Fix header preservation when writing CSVs

### DIFF
--- a/Static/Python/FillMissingData.py
+++ b/Static/Python/FillMissingData.py
@@ -350,7 +350,7 @@ def main() -> None:
     template = list(pd.read_csv(MASTER_CSV, nrows=0).columns)
     df = df[template + [c for c in df.columns if c not in template]]
     # save out the newly filled CSV
-    df.to_csv(OUT_CSV, index=False, quoting=csv.QUOTE_MINIMAL)
+    df.to_csv(OUT_CSV, index=False, quoting=csv.QUOTE_MINIMAL, na_rep="")
     print(f"Saved → {OUT_CSV}")
 
 if __name__ == "__main__":

--- a/Static/Python/GetLinks.py
+++ b/Static/Python/GetLinks.py
@@ -135,7 +135,7 @@ if needs.empty:
     df = df.reindex(
         columns=template_cols + [c for c in df.columns if c not in template_cols]
     )
-    df.to_csv(OUTPUT, index=False)
+    df.to_csv(OUTPUT, index=False, na_rep="")
     print(f"All links present – written straight to {OUTPUT.relative_to(REPO)}")
     raise SystemExit
 
@@ -445,7 +445,7 @@ template_cols = list(pd.read_csv(MASTER, nrows=0).columns)
 df = df.reindex(
     columns=template_cols + [c for c in df.columns if c not in template_cols]
 )
-df.to_csv(OUTPUT, index=False)
+df.to_csv(OUTPUT, index=False, na_rep="")
 try:
     rel = OUTPUT.relative_to(REPO)
 except ValueError:  # outside the repo – show full path

--- a/Static/Python/PDFScraper.py
+++ b/Static/Python/PDFScraper.py
@@ -217,7 +217,7 @@ def extract_images(df: pd.DataFrame) -> None:
                 "Botanical Name": bot_name,
                 "Common Name": com_name,
             })
-    pd.DataFrame(image_rows).to_csv(MAP_CSV, index=False)
+    pd.DataFrame(image_rows).to_csv(MAP_CSV, index=False, na_rep="")
     safe_print(f"📸 Extracted {len(image_rows)} images to {IMG_DIR}")
     safe_print(f"🗂  Mapping written to {MAP_CSV}")
 
@@ -234,7 +234,7 @@ def extract_images(df: pd.DataFrame) -> None:
 # ─── Main ────────────────────────────────────────────────────────────────
 def main():
     df = pd.DataFrame(extract_rows(), columns=COLUMNS)
-    df.to_csv(OUT_CSV, index=False, quoting=csv.QUOTE_MINIMAL)
+    df.to_csv(OUT_CSV, index=False, quoting=csv.QUOTE_MINIMAL, na_rep="")
     safe_print(f"✅ Saved → {OUT_CSV.name} ({len(df)} rows)")
     extract_images(df)
 

--- a/Tools/rebase_master.py
+++ b/Tools/rebase_master.py
@@ -76,4 +76,4 @@ new["Link: Pleasantrunnursery.com"] = old.get("Link: Pleasant Run", "")
 new["Link: Newmoonnursery.com"] = old.get("Link: New Moon", "")
 new["Link: Pinelandsnursery.com"] = old.get("Link: Pinelands", "")
 
-new.to_csv(args.output, index=False)
+new.to_csv(args.output, index=False, na_rep="")


### PR DESCRIPTION
## Summary
- ensure `to_csv()` fills missing columns with an empty string
- preserve all template columns, including Pinelands nursery link

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 - <<'PY'
import pandas as pd, csv
master='Static/Templates/Plants_Linked_Filled_Master.csv'
df=pd.read_csv(master)
base=df.drop(columns=['Link: Pinelandsnursery.com'])
template_cols=list(pd.read_csv(master, nrows=0).columns)
reindexed=base.reindex(columns=template_cols + [c for c in base.columns if c not in template_cols])
reindexed.to_csv('/tmp/test.csv', index=False, na_rep='')
with open('/tmp/test.csv') as f:
    reader=csv.reader(f)
    header=next(reader)
    print('header columns',len(header))
    for i,row in zip(range(3),reader):
        print('row',i,len(row))
PY

------
https://chatgpt.com/codex/tasks/task_e_6840b1b694708326a2e7d39b19d37d54