### PR TITLE
Add AGCP Regional Status support

### DIFF
--- a/Static/Python/FillMissingData.py
+++ b/Static/Python/FillMissingData.py
@@ -59,6 +59,7 @@ WF_COLS = {
     "Water",
     "Attracts",
     "Characteristics",
+    "AGCP Regional Status",
 }
 PR_COLS = {
     "Tolerates",
@@ -233,6 +234,7 @@ def parse_wf(html: str, mbg_missing: bool = False) -> Dict[str, Optional[str]]:
         "Bloom Time":  month_rng(grab(text, r"Bloom Time")),
         "Habitats":    grab(text, r"Native Habitat"),
         "Soil Description": grab(text, r"Soil Description"),
+        "AGCP Regional Status": grab(text, r"(?:National Wetland Indicator Status|AGCP)"),
     }
     if mbg_missing:
         # fill core fields when MBG had no data

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ Every field is first scraped from the Rutgers PDF. Missing values are filled fro
 | Attracts | PDF → Pleasant Run + WF + MBG | |
 | Soil Description | PDF → Wildflower | |
 | Distribution Zone | PDF → MBG | |
-| AGCP Regional Status | PDF → Wildflower | |
+| AGCP Regional Status | PDF → Wildflower | from "National Wetland Indicator Status" |
 | Link: Missouri Botanical Garden | from GetLinks | |
 | Link: Wildflower.org | from GetLinks | |
 | Link: Pleasantrunnursery.com | from GetLinks | |


### PR DESCRIPTION
## Summary
- include `AGCP Regional Status` among the Wildflower columns
- parse national wetland indicator/AGCP text from Wildflower pages
- document this column in README

## Testing
- `python -m py_compile Static/Python/FillMissingData.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b1b75d8c8326b7ad7d16f5b4ca5a