### PR TITLE
Add PyMuPDF dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ Pillow
 lxml==5.2.1
 selenium==4.20.0
 PyPDF2==3.0.1
+PyMuPDF
 Customtkinter
 tkinter
 black
@@ -28,6 +29,9 @@ To install all dependencies:
 ```bash
 pip install -r requirements.txt
 ```
+
+PyMuPDF (``fitz``) handles PDF image extraction and installs automatically with
+the command above.
 
 > **Chrome Note**: To use Selenium, you must install [Google Chrome Portable](https://portableapps.com/apps/internet/google_chrome_portable) and place it inside the `Static/GoogleChromePortable/` folder. Also ensure `chromedriver.exe` is in `Static/Python/`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ fpdf2
 pdfplumber
 Pillow
 PyPDF2
+PyMuPDF
 lxml
 tqdm
 requests


### PR DESCRIPTION
## Summary
- list `PyMuPDF` under core dependencies
- add `PyMuPDF` to the README dependency list
- mention `pip install -r requirements.txt` installs it

## Testing
- `black --check .`
- `python Tools/list_files.py | head`
- `pip install -r requirements.txt` *(fails: no matching distribution for tkinter)*

------
https://chatgpt.com/codex/tasks/task_e_6840b781a1fc8326b120ead006ce7247