### PR TITLE
Fix handling of Distribution Zone column

### DIFF
--- a/Static/Python/FillMissingData.py
+++ b/Static/Python/FillMissingData.py
@@ -412,9 +412,13 @@ def main(in_csv: Path = IN_CSV, out_csv: Path = OUT_CSV) -> None:
             "Link: Pleasantrunnursery.com": "PR Link",
             "Link: Newmoonnursery.com": "NM Link",
             "Link: Pinelandsnursery.com": "PN Link",
-            "Distribution": "Zone",
+            "Distribution": "Distribution Zone",
+            "Distribution Zone": "Distribution Zone",
         }
     )
+
+    if "Distribution Zone" in df.columns:
+        df = df.rename(columns={"Distribution Zone": "Zone"})
 
     # ensure a Key column exists for identifying rows uniquely
     if "Key" not in df.columns:
@@ -533,6 +537,9 @@ def main(in_csv: Path = IN_CSV, out_csv: Path = OUT_CSV) -> None:
                     elif missing(df.at[idx, col]):
                         df.at[idx, col] = val
                 time.sleep(SLEEP_BETWEEN)
+
+    if "Zone" in df.columns:
+        df = df.rename(columns={"Zone": "Distribution Zone"})
 
     # reorder columns to match original template, keeping extras at end
     template = list(pd.read_csv(MASTER_CSV, nrows=0).columns)


### PR DESCRIPTION
## Summary
- support `Distribution Zone` column in FillMissingData
- convert it back to the master template name before output
- demonstrate script starts without KeyError

## Testing
- `black --check .`
- `python Static/Python/FillMissingData.py --in_csv Static/Templates/Plants_Linked_Filled_Master.csv --out_csv /tmp/out.csv` (interrupted after verifying progress)

------
https://chatgpt.com/codex/tasks/task_e_6840c5753f508326973e56532473fa5b