### PR TITLE
Fix TOC pages in PDF scraper

### DIFF
--- a/Static/Python/PDFScraper.py
+++ b/Static/Python/PDFScraper.py
@@ -189,7 +189,11 @@ def extract_rows() -> List[Dict[str, str]]:
             if page_num in skip_pages:
                 continue
             text = pg.extract_text() or ""
+            if re.search(r"table of contents", text, re.I):
+                continue
             lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+            if sum("..." in ln for ln in lines) >= 3:
+                continue
             bot_idx = None
             bot_name = com_name = ""
 


### PR DESCRIPTION
## Summary
- skip table of contents pages when extracting rows

## Testing
- `black --check Static/Python/PDFScraper.py`
- `python Static/Python/PDFScraper.py --in_pdf "Static/Templates/Plant Guide 2025 Update.pdf" --out_csv /tmp/out.csv --img_dir /tmp/pdf_images --map_csv /tmp/map.csv` *(fails: KeyboardInterrupt after start)*

------
https://chatgpt.com/codex/tasks/task_e_68411a143664832687aab0350fcd1dac