### PR TITLE
Fix PDFScraper page type detection

### DIFF
--- a/Static/Python/PDFScraper.py
+++ b/Static/Python/PDFScraper.py
@@ -167,11 +167,14 @@ def build_page_type_map(pdf_path: Path) -> Dict[int, str]:
         "TREES": "Trees",
     }
     page_type_map = {}
+    last_type = ""
     with pdfplumber.open(pdf_path) as pdf:
         for idx, page in enumerate(pdf.pages, start=1):
             text = (page.extract_text() or "").upper()
             match = next((v for k, v in valid_types.items() if k in text), "")
-            page_type_map[idx] = match
+            if match:
+                last_type = match
+            page_type_map[idx] = last_type
     return page_type_map
 
 


### PR DESCRIPTION
## Summary
- keep the previously seen page type when scanning the guide

## Testing
- `black Static/Python/PDFScraper.py`
- `python3 Static/Python/PDFScraper.py > /tmp/scraper_run.txt 2>&1`
- `grep -A2 'Saved' /tmp/scraper_run.txt`

------
https://chatgpt.com/codex/tasks/task_e_68411ca3b4008326b13ff277d7e8a691