### PR TITLE
Update image naming scheme

### DIFF
--- a/Static/Python/GeneratePDF.py
+++ b/Static/Python/GeneratePDF.py
@@ -190,7 +190,7 @@ class PlantPDF(FPDF):
         self.ln(2)
 
         # ── Images ──
-        images = sorted(list(IMG_DIR.glob(f"*_{base_name}_*.jpg")) + list(IMG_DIR.glob(f"*_{base_name}_*.png")))    # Find up to 3 images
+        images = sorted(list(IMG_DIR.glob(f"{base_name}_*.jpg")) + list(IMG_DIR.glob(f"{base_name}_*.png")))    # Find up to 3 images
         count = max(1, min(len(images), 3))
         margin = self.l_margin
         avail_w = self.w - margin - self.r_margin
@@ -331,8 +331,8 @@ def try_image_path(base_dir, filenames):
             return path
     return None
 
-left_logo = try_image_path(logo_dir, ["001_rutgers_cooperative_extension_1.jpg", "001_rutgers_cooperative_extension_1.png"])
-right_logo = try_image_path(logo_dir, ["001_rutgers_cooperative_extension_2.jpg", "001_rutgers_cooperative_extension_2.png"])
+left_logo = try_image_path(logo_dir, ["rutgers_cooperative_extension_0.jpg", "rutgers_cooperative_extension_0.png"])
+right_logo = try_image_path(logo_dir, ["rutgers_cooperative_extension_1.jpg", "rutgers_cooperative_extension_1.png"])
 if left_logo:
     pdf.image(str(left_logo), x=pdf.l_margin, y=20, h=30)
 if right_logo:

--- a/Static/Python/PDFScraper.py
+++ b/Static/Python/PDFScraper.py
@@ -200,8 +200,8 @@ def extract_images(df: pd.DataFrame) -> None:
         for img_index, img in enumerate(images, start=1):
             xref = img[0]
             pix = fitz.Pixmap(doc, xref)
-            count = page_image_count[base_name] + 1
-            filename = f"{page_index:03d}_{base_name}_{count}.png"
+            count = page_image_count[base_name]
+            filename = f"{base_name}_{count}.png"
             output_path = IMG_DIR / filename
             if pix.n < 5:
                 pix.save(output_path)

--- a/TEst.py
+++ b/TEst.py
@@ -235,8 +235,8 @@ def extract_images(df: pd.DataFrame) -> None:
         for img_index, img in enumerate(images, start=1):
             xref = img[0]
             pix  = fitz.Pixmap(doc, xref)
-            count = page_image_count[base_name] + 1
-            filename = f"{page_index:03d}_{base_name}_{count}.png"
+            count = page_image_count[base_name]
+            filename = f"{base_name}_{count}.png"
             output_path = IMG_DIR / filename
             if pix.n < 5:
                 pix.save(output_path)

--- a/Tools/list_files.py
+++ b/Tools/list_files.py
@@ -31,6 +31,3 @@ def list_all_files(base_dir):
 
 if __name__ == "__main__":
     list_all_files(".")
-
-
-#python list_files.py > file_paths.md

--- a/readme.md
+++ b/readme.md
@@ -119,7 +119,7 @@ pip install -r requirements.txt
 ## 🔧 Notes
 
 * Chrome/Selenium requires a portable installation of Chrome.
-* Image filenames use: `page#_botanical_slug_count.jpg`.
+* Image filenames use: `botanical_slug_index.jpg`.
 * PDF sections auto-group by type (Herbaceous, Ferns, Shrubs, etc).
 * `Excelify2.py` sets filters on select columns and highlights missing values.
 * Scripts are designed to be rerun with override support.


### PR DESCRIPTION
## Summary
- switch naming to `botanical_slug_index` in PDFScraper
- match updated image pattern in GeneratePDF
- adjust sample logo filenames
- update README notes about naming
- clean stray text from Tools/list_files.py

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684128b36d608326a65ebd5e0848e998