### PR TITLE
Drop Page in PDF column

### DIFF
--- a/Static/Python/Excelify2.py
+++ b/Static/Python/Excelify2.py
@@ -61,7 +61,7 @@ for i, column_cells in enumerate(ws.columns, start=1):
     ws.column_dimensions[get_column_letter(i)].width = min(max_length + 2, 50)
 
 # ─── Step 3: Apply filters to specific columns ──────────────────────────────
-filter_cols = [
+desired_filters = [
     "Page in PDF",
     "Plant Type",
     "Bloom Color",
@@ -69,6 +69,7 @@ filter_cols = [
     "Water",
 ]
 header = [cell.value for cell in ws[1]]
+filter_cols = [c for c in desired_filters if c in header]
 filter_indices = [i + 1 for i, val in enumerate(header) if val in filter_cols]
 if filter_indices:
     col_range = f"{get_column_letter(min(filter_indices))}1:{get_column_letter(max(filter_indices))}1"

--- a/Static/Python/PDFScraper.py
+++ b/Static/Python/PDFScraper.py
@@ -328,9 +328,10 @@ def extract_images(df: pd.DataFrame) -> None:
 # ─── Main ────────────────────────────────────────────────────────────────
 def main():
     df = pd.DataFrame(extract_rows(), columns=COLUMNS)
+    extract_images(df)
+    df.drop(columns=["Page in PDF"], inplace=True, errors="ignore")
     df.to_csv(OUT_CSV, index=False, quoting=csv.QUOTE_MINIMAL, na_rep="")
     safe_print(f"✅ Saved → {OUT_CSV.name} ({len(df)} rows)")
-    extract_images(df)
 
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,6 @@ Every field is first scraped from the Rutgers PDF. Missing values are filled fro
 
 | **Column** | **Data Hierarchy** | **Formatting / Notes** |
 | ---------- | ------------------ | ---------------------- |
-| Page in PDF | PDF only | |
 | Plant Type | PDF only | |
 | Key | generated from Botanical Name | |
 | Botanical Name | PDF only | |


### PR DESCRIPTION
## Summary
- remove the `Page in PDF` column from final CSV
- keep Excel filter list dynamic
- update docs for new CSV layout

## Testing
- `black --check .`
- `python Static/Python/PDFScraper.py --in_pdf Static/Templates/Plant\ Guide\ Data\ Base.pdf --out_csv Static/Outputs/Plants_NeedLinks.csv --img_dir Static/Outputs/pdf_images_test --map_csv Static/Outputs/image_map_test.csv`
- `timeout 15s python Static/Python/FillMissingData.py --in_csv Static/Outputs/Plants_NeedLinks.csv --out_csv Static/Outputs/Plants_Linked_Filled.csv` (fails: terminated after 15s)
- `python Static/Python/Excelify2.py --in_csv Static/Outputs/Plants_NeedLinks.csv --out_xlsx Static/Outputs/test.xlsx`


------
https://chatgpt.com/codex/tasks/task_e_68419143615083269ff991af21c0804f