### PR TITLE
Use header-only column sizing in Excelify2

### DIFF
--- a/Static/Python/Excelify2.py
+++ b/Static/Python/Excelify2.py
@@ -68,12 +68,11 @@ for cell in ws[1]:
 
 
 def autofit_columns(ws: Worksheet) -> None:
-    """Resize each column based on the maximum cell length."""
+    """Resize each column based solely on its header label."""
 
-    for column_cells in ws.columns:
-        max_length = max(len(str(cell.value or "")) for cell in column_cells)
-        letter = get_column_letter(column_cells[0].column)
-        ws.column_dimensions[letter].width = max_length + 2
+    for cell in ws[1]:
+        letter = get_column_letter(cell.column)
+        ws.column_dimensions[letter].width = len(str(cell.value or "")) + 2
 
 
 autofit_columns(ws)


### PR DESCRIPTION
## Summary
- update `autofit_columns` to size columns based on header length
- verify Excel export succeeds

## Testing
- `pip install -r <(grep -v tkinter requirements.txt)`
- `python Static/Python/Excelify2.py --in_csv Static/Outputs/Plants_Linked_Filled.csv --out_xlsx Static/Outputs/test.xlsx`


------
https://chatgpt.com/codex/tasks/task_e_6841a87c93c883268b3d726824caa614