### PR TITLE
Use col_idx for autofit

### DIFF
--- a/Static/Python/Excelify2.py
+++ b/Static/Python/Excelify2.py
@@ -71,7 +71,7 @@ def autofit_columns(ws: Worksheet) -> None:
     """Resize each column based solely on its header label."""
 
     for cell in ws[1]:
-        letter = get_column_letter(cell.column)
+        letter = get_column_letter(cell.col_idx)
         ws.column_dimensions[letter].width = len(str(cell.value or "")) + 2
 
 


### PR DESCRIPTION
## Summary
- tweak Excelify2 column sizing to use `cell.col_idx`

## Testing
- `black --check Static/Python/Excelify2.py`
- `python Static/Python/Excelify2.py --in_csv Static/Outputs/Plants_Linked_Filled.csv --out_xlsx Static/Outputs/test.xlsx`

------
https://chatgpt.com/codex/tasks/task_e_6841a9a886e083268777e4f23050a0fb