### PR TITLE
Allow overriding master template CSVs

### DIFF
--- a/Static/Python/Excelify2.py
+++ b/Static/Python/Excelify2.py
@@ -24,6 +24,11 @@ parser.add_argument(
     default="Static/Outputs/Plants_Linked_Filled_Review.xlsx",
     help="Output Excel file",
 )
+parser.add_argument(
+    "--template_csv",
+    default="Static/Templates/Plants_Linked_Filled_Master.csv",
+    help="CSV file containing column template",
+)
 args = parser.parse_args()
 
 # ─── File Paths ───────────────────────────────────────────────────────────
@@ -31,14 +36,11 @@ BASE = Path(__file__).resolve().parent
 REPO = BASE.parent.parent
 CSV_FILE = (REPO / args.in_csv).resolve()
 XLSX_FILE = (REPO / args.out_xlsx).resolve()
+TEMPLATE_CSV = (REPO / args.template_csv).resolve()
 
 # ─── Step 1: Load CSV and write it to a basic Excel file ──────────────────
 df = pd.read_csv(CSV_FILE, dtype=str).fillna("")
-template_cols = list(
-    pd.read_csv(
-        REPO / "Static/Templates/Plants_Linked_Filled_Master.csv", nrows=0
-    ).columns
-)
+template_cols = list(pd.read_csv(TEMPLATE_CSV, nrows=0).columns)
 df = df.reindex(
     columns=template_cols + [c for c in df.columns if c not in template_cols]
 )

--- a/Static/Python/FillMissingData.py
+++ b/Static/Python/FillMissingData.py
@@ -37,6 +37,11 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="Static/Outputs/Plants_Linked_Filled.csv",
         help="Output CSV file",
     )
+    parser.add_argument(
+        "--master_csv",
+        default="Static/Templates/Plants_Linked_Filled_Master.csv",
+        help="CSV file containing column template",
+    )
     return parser.parse_args(argv)
 
 
@@ -423,7 +428,11 @@ def parse_pn(html: str) -> Dict[str, Optional[str]]:
 
 
 # ─── Main Processing Loop ─────────────────────────────────────────────────
-def main(in_csv: Path = IN_CSV, out_csv: Path = OUT_CSV) -> None:
+def main(
+    in_csv: Path = IN_CSV,
+    out_csv: Path = OUT_CSV,
+    master_csv: Path = MASTER_CSV,
+) -> None:
     # load CSV into a DataFrame, ensuring all empty cells become blank strings
     df = pd.read_csv(in_csv, dtype=str).fillna("")
 
@@ -570,7 +579,7 @@ def main(in_csv: Path = IN_CSV, out_csv: Path = OUT_CSV) -> None:
         df = df.rename(columns={"Habitats": "Native Habitats"})
 
     # reorder columns to match original template, keeping extras at end
-    template = list(pd.read_csv(MASTER_CSV, nrows=0).columns)
+    template = list(pd.read_csv(master_csv, nrows=0).columns)
     df = df.rename(
         columns={
             "MBG Link": "Link: Missouri Botanical Garden",
@@ -589,5 +598,7 @@ def main(in_csv: Path = IN_CSV, out_csv: Path = OUT_CSV) -> None:
 if __name__ == "__main__":
     cli_args = parse_cli_args()
     main(
-        repo_path(cli_args.in_csv), repo_path(cli_args.out_csv)
+        repo_path(cli_args.in_csv),
+        repo_path(cli_args.out_csv),
+        repo_path(cli_args.master_csv),
     )  # run when executed as a script

--- a/Static/Python/GeneratePDF.py
+++ b/Static/Python/GeneratePDF.py
@@ -28,6 +28,11 @@ parser.add_argument(
 parser.add_argument(
     "--img_dir", default="Static/Outputs/pdf_images/jpeg", help="Image directory"
 )
+parser.add_argument(
+    "--template_csv",
+    default="Static/Templates/Plants_Linked_Filled_Master.csv",
+    help="CSV file containing column template",
+)
 args = parser.parse_args()
 
 logging.basicConfig(level=logging.INFO)
@@ -42,15 +47,12 @@ CSV_FILE = (
 IMG_DIR = Path(args.img_dir) if args.img_dir else BASE_DIR / "Static/Outputs/pdf_images"
 OUTPUT = Path(args.out_pdf)
 logo_dir = IMG_DIR.parent if IMG_DIR.name == "jpeg" else IMG_DIR
+TEMPLATE_CSV = Path(args.template_csv)
 
 
 # ─── Load and Prepare Data ────────────────────────────────────────────────
 df = pd.read_csv(CSV_FILE, dtype=str).fillna("")  # Read CSV, empty cells → ""
-template_cols = list(
-    pd.read_csv(
-        Path("Static/Templates/Plants_Linked_Filled_Master.csv"), nrows=0
-    ).columns
-)
+template_cols = list(pd.read_csv(TEMPLATE_CSV, nrows=0).columns)
 df = df.reindex(
     columns=template_cols + [c for c in df.columns if c not in template_cols]
 )


### PR DESCRIPTION
## Summary
- enable choosing master CSV in `FillMissingData.py`
- add `--template_csv` argument to `GeneratePDF.py`
- add `--template_csv` argument to `Excelify2.py`

## Testing
- `python Static/Python/FillMissingData.py --in_csv /tmp/small.csv --out_csv /tmp/out.csv --master_csv Static/Templates/Plants_Linked_Filled_Master.csv`
- `python Static/Python/GeneratePDF.py --in_csv /tmp/small.csv --out_pdf /tmp/out.pdf --template_csv Static/Templates/Plants_Linked_Filled_Master.csv`
- `python Static/Python/Excelify2.py --in_csv /tmp/small.csv --out_xlsx /tmp/out.xlsx --template_csv Static/Templates/Plants_Linked_Filled_Master.csv`


------
https://chatgpt.com/codex/tasks/task_e_6841d912eb1c8326b21af8c264146af8