### PR TITLE
Improve repo_dir helper detection

### DIFF
--- a/Python/Excelify2.py
+++ b/Python/Excelify2.py
@@ -16,7 +16,7 @@ import black
 parser = argparse.ArgumentParser(description="Export formatted Excel from CSV")
 parser.add_argument(
     "--in_csv",
-    default="Outputs/Plants_Linked_Filled.csv",          # ← moved
+    default="Outputs/Plants_Linked_Filled.csv",  # ← moved
     help="Input CSV file with filled data",
 )
 parser.add_argument(
@@ -26,7 +26,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--template_csv",
-    default="Templates/Plants_Linked_Filled_Master.csv", # ← moved
+    default="Templates/Plants_Linked_Filled_Master.csv",  # ← moved
     help="CSV file containing column template",
 )
 args = parser.parse_args()
@@ -35,15 +35,17 @@ args = parser.parse_args()
 # ─── Path helpers ─────────────────────────────────────────────────────────
 def repo_dir() -> Path:
     """Folder that contains the helper EXE (frozen) or repo root (source)."""
-    if getattr(sys, "frozen", False):          # running as a PyInstaller exe
-        return Path(sys.executable).resolve().parent
-    return Path(__file__).resolve().parent.parent.parent  # Static/Python/ → repo
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        return exe_dir.parent if exe_dir.name.lower() == "helpers" else exe_dir
+    # Python scripts live two levels below the repo root
+    return Path(__file__).resolve().parent.parent
 
 
 REPO = repo_dir()
-CSV_FILE      = (REPO / args.in_csv).resolve()
-XLSX_FILE     = (REPO / args.out_xlsx).resolve()
-TEMPLATE_CSV  = (REPO / args.template_csv).resolve()
+CSV_FILE = (REPO / args.in_csv).resolve()
+XLSX_FILE = (REPO / args.out_xlsx).resolve()
+TEMPLATE_CSV = (REPO / args.template_csv).resolve()
 
 # ensure the Outputs folder exists when running on a flash-drive
 XLSX_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/Python/FillMissingData.py
+++ b/Python/FillMissingData.py
@@ -15,21 +15,30 @@ from tqdm import tqdm
 # ─── CLI ──────────────────────────────────────────────────────────────────
 def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Fill missing plant fields using MBG/WF")
-    p.add_argument("--in_csv",    default="Outputs/Plants_Linked.csv",           help="Input CSV")
-    p.add_argument("--out_csv",   default="Outputs/Plants_Linked_Filled.csv",    help="Output CSV")
-    p.add_argument("--master_csv",default="Templates/Plants_Linked_Filled_Master.csv",
-                   help="Column template CSV")
+    p.add_argument("--in_csv", default="Outputs/Plants_Linked.csv", help="Input CSV")
+    p.add_argument(
+        "--out_csv", default="Outputs/Plants_Linked_Filled.csv", help="Output CSV"
+    )
+    p.add_argument(
+        "--master_csv",
+        default="Templates/Plants_Linked_Filled_Master.csv",
+        help="Column template CSV",
+    )
     return p.parse_args(argv)
 
 
 args = parse_cli_args()
 
+
 # ─── Path helpers ─────────────────────────────────────────────────────────
 def repo_dir() -> Path:
-    """Return bundle root when frozen or repo root when running from source."""
-    if getattr(sys, "frozen", False):          # running as helper EXE
-        return Path(sys.executable).resolve().parent
-    return Path(__file__).resolve().parent.parent.parent   # Static/Python/ → repo
+    """Return bundle root when frozen, or repo root when running from source."""
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        return exe_dir.parent if exe_dir.name.lower() == "helpers" else exe_dir
+    # scripts live in `Python/` at repo root
+    return Path(__file__).resolve().parent.parent
+
 
 REPO = repo_dir()
 
@@ -50,8 +59,8 @@ def repo_path(arg: str | Path) -> Path:
     return cand if cand.exists() else (REPO / p).resolve()
 
 
-IN_CSV     = repo_path(args.in_csv)
-OUT_CSV    = repo_path(args.out_csv)
+IN_CSV = repo_path(args.in_csv)
+OUT_CSV = repo_path(args.out_csv)
 MASTER_CSV = repo_path(args.master_csv)
 
 # auto-create Outputs the first time the helper runs from a fresh flash drive

--- a/Python/GeneratePDF.py
+++ b/Python/GeneratePDF.py
@@ -19,17 +19,17 @@ from fpdf.errors import FPDFException
 parser = argparse.ArgumentParser(description="Generate plant guide PDF")
 parser.add_argument(
     "--in_csv",
-    default="Outputs/Plants_Linked_Filled.csv",           # ← moved
+    default="Outputs/Plants_Linked_Filled.csv",  # ← moved
     help="Input CSV file with filled data",
 )
 parser.add_argument(
     "--out_pdf",
-    default="Outputs/Plant_Guide_EXPORT.pdf",             # ← moved
+    default="Outputs/Plant_Guide_EXPORT.pdf",  # ← moved
     help="Output PDF file",
 )
 parser.add_argument(
     "--img_dir",
-    default="Outputs/pdf_images/jpeg",                    # ← moved
+    default="Outputs/pdf_images/jpeg",  # ← moved
     help="Folder that holds plant JPEGs",
 )
 parser.add_argument(
@@ -43,17 +43,18 @@ args = parser.parse_args()
 # ─── Path helpers ─────────────────────────────────────────────────────────
 def repo_dir() -> Path:
     """Return bundle root when frozen, or repo root when running from source."""
-    if getattr(sys, "frozen", False):          # PyInstaller helper EXE
-        return Path(sys.executable).resolve().parent
-    # source layout: Static/Python/GeneratePDF.py → ../../ (repo root)
-    return Path(__file__).resolve().parent.parent.parent
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        return exe_dir.parent if exe_dir.name.lower() == "helpers" else exe_dir
+    # scripts are in `Python/`, so repo root is two parents up
+    return Path(__file__).resolve().parent.parent
 
 
 REPO = repo_dir()
-CSV_FILE      = (REPO / args.in_csv).resolve()
-IMG_DIR       = (REPO / args.img_dir).resolve()
-OUTPUT        = (REPO / args.out_pdf).resolve()
-TEMPLATE_CSV  = (REPO / args.template_csv).resolve()
+CSV_FILE = (REPO / args.in_csv).resolve()
+IMG_DIR = (REPO / args.img_dir).resolve()
+OUTPUT = (REPO / args.out_pdf).resolve()
+TEMPLATE_CSV = (REPO / args.template_csv).resolve()
 
 # auto-create Outputs on first run from a clean flash-drive
 OUTPUT.parent.mkdir(parents=True, exist_ok=True)

--- a/Python/GetLinks.py
+++ b/Python/GetLinks.py
@@ -18,12 +18,11 @@ from urllib.parse import quote_plus
 
 # ─── CLI ────────────────────────────────────────────────────────────────
 parser = argparse.ArgumentParser(description="Fill missing plant site links")
-parser.add_argument("--in_csv",
-                    default="Outputs/Plants_NeedLinks.csv")        # ← moved
-parser.add_argument("--out_csv",
-                    default="Outputs/Plants_Linked.csv")           # ← moved
-parser.add_argument("--master_csv",
-                    default="Templates/Plants_Linked_Filled_Master.csv")  # ← moved
+parser.add_argument("--in_csv", default="Outputs/Plants_NeedLinks.csv")  # ← moved
+parser.add_argument("--out_csv", default="Outputs/Plants_Linked.csv")  # ← moved
+parser.add_argument(
+    "--master_csv", default="Templates/Plants_Linked_Filled_Master.csv"
+)  # ← moved
 parser.add_argument("--chromedriver", default="", help="Path to chromedriver.exe")
 parser.add_argument("--chrome_binary", default="", help="Path to chrome.exe")
 args = parser.parse_args()
@@ -32,15 +31,19 @@ args = parser.parse_args()
 from pathlib import Path
 import sys
 
-def repo_dir() -> Path:
-    """Bundle root if frozen, else repo root."""
-    if getattr(sys, "frozen", False):             # running as GetLinks.exe
-        return Path(sys.executable).resolve().parent
-    # source: Static/Python/GetLinks.py  →  repo/
-    return Path(__file__).resolve().parent.parent.parent
 
-REPO   = repo_dir()
-STATIC = REPO / "Static"          # still contains themes, GoogleChromePortable, etc.
+def repo_dir() -> Path:
+    """Return bundle root when frozen, or repo root when running from source."""
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        return exe_dir.parent if exe_dir.name.lower() == "helpers" else exe_dir
+    # scripts now live directly in `Python/`
+    return Path(__file__).resolve().parent.parent
+
+
+REPO = repo_dir()
+STATIC = REPO / "Static"  # still contains themes, GoogleChromePortable, etc.
+
 
 def repo_path(arg: str | Path) -> Path:
     """
@@ -56,9 +59,10 @@ def repo_path(arg: str | Path) -> Path:
     cand = (Path(__file__).resolve().parent / p).resolve()
     return cand if cand.exists() else (REPO / p).resolve()
 
-INPUT   = repo_path(args.in_csv)         # e.g.  …/Outputs/Plants_NeedLinks.csv
-OUTPUT  = repo_path(args.out_csv)        # e.g.  …/Outputs/Plants_Linked.csv
-MASTER  = repo_path(args.master_csv)     # e.g.  …/Templates/Plants_Linked_Filled_Master.csv
+
+INPUT = repo_path(args.in_csv)  # e.g.  …/Outputs/Plants_NeedLinks.csv
+OUTPUT = repo_path(args.out_csv)  # e.g.  …/Outputs/Plants_Linked.csv
+MASTER = repo_path(args.master_csv)  # e.g.  …/Templates/Plants_Linked_Filled_Master.csv
 
 # first run from a fresh flash-drive: make sure Outputs exists
 OUTPUT.parent.mkdir(parents=True, exist_ok=True)
@@ -248,7 +252,6 @@ def find_driver() -> Path:
         "Put one in Static\\Python or rely on the copy under "
         "Static\\GoogleChromePortable\\App\\Chrome-bin\\<version>\\"
     )
-
 
 
 CHROME_EXE = find_chrome()

--- a/Python/PDFScraper.py
+++ b/Python/PDFScraper.py
@@ -19,35 +19,39 @@ from PIL import Image
 parser = argparse.ArgumentParser(description="Extract plant data from a PDF guide.")
 parser.add_argument(
     "--in_pdf",
-    default="Templates/Plant Guide 2025 Update.pdf",          # ← moved
+    default="Templates/Plant Guide 2025 Update.pdf",  # ← moved
     help="PDF input file",
 )
 parser.add_argument(
     "--out_csv",
-    default="Outputs/Plants_NeedLinks.csv",                    # ← moved
+    default="Outputs/Plants_NeedLinks.csv",  # ← moved
     help="CSV output file",
 )
 parser.add_argument(
     "--img_dir",
-    default="Outputs/pdf_images",                             # ← moved
+    default="Outputs/pdf_images",  # ← moved
     help="Directory for PNG dump",
 )
 parser.add_argument(
     "--map_csv",
-    default="Outputs/image_map.csv",                          # ← moved
+    default="Outputs/image_map.csv",  # ← moved
     help="Image → plant map CSV",
 )
 args = parser.parse_args()
 
+
 # ─── Path helpers ────────────────────────────────────────────────────────
 def repo_dir() -> Path:
-    """Return bundle root if frozen, else repo root when running from source."""
-    if getattr(sys, "frozen", False):              # running as PDFScraper.exe
-        return Path(sys.executable).resolve().parent
-    # source layout: Static/Python/PDFScraper.py  →  ../../ (repo root)
-    return Path(__file__).resolve().parent.parent.parent
+    """Return bundle root when frozen, or repo root when running from source."""
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        return exe_dir.parent if exe_dir.name.lower() == "helpers" else exe_dir
+    # scripts now live in `Python/` → repo is two parents up
+    return Path(__file__).resolve().parent.parent
+
 
 REPO = repo_dir()
+
 
 def repo_path(rel: str | Path) -> Path:
     """
@@ -63,10 +67,11 @@ def repo_path(rel: str | Path) -> Path:
     cand = (Path(__file__).resolve().parent / p).resolve()
     return cand if cand.exists() else (REPO / p).resolve()
 
+
 PDF_PATH = repo_path(args.in_pdf)
-OUT_CSV  = repo_path(args.out_csv)
-IMG_DIR  = repo_path(args.img_dir)
-MAP_CSV  = repo_path(args.map_csv)
+OUT_CSV = repo_path(args.out_csv)
+IMG_DIR = repo_path(args.img_dir)
+MAP_CSV = repo_path(args.map_csv)
 
 # ensure folders exist when running from a fresh flash-drive
 IMG_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- detect when helper binaries live in a `helpers` folder
- ascend two parents from Python sources
- keep repo path resolution consistent across helper scripts

## Testing
- `black --check Python/Excelify2.py Python/FillMissingData.py Python/GeneratePDF.py Python/GetLinks.py Python/PDFScraper.py`
- `python Python/PDFScraper.py --help`
- `python Python/GetLinks.py --help`
- `python Python/FillMissingData.py --help`
- `python Python/Excelify2.py --help`
- `python Python/GeneratePDF.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6846c009e9e48326aa6926fea6983322