### PR TITLE
Update docs for Lite launcher

### DIFF
--- a/Launcher_lite.py
+++ b/Launcher_lite.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Launcher.py – CTk GUI for the plant-database tool-chain
+# Launcher_lite.py – CTk GUI for the plant-database tool-chain
 # 2025-06-09  portable-layout & resizable console edition
 
 import sys, subprocess, threading, queue, customtkinter as ctk

--- a/Run.md
+++ b/Run.md
@@ -55,7 +55,7 @@ foreach ($h in $helpers) {
 ### 3.2  Compile the launcher (onedir)
 
 ```powershell
-pyinstaller Launcher.py --onedir --noconfirm --windowed --name Launcher `
+pyinstaller Launcher_lite.py --onedir --noconfirm --windowed --name Launcher `
     --icon "Static/themes/leaf.ico" `
     --add-data "Static;_internal/Static" `
     --add-data "Static/Templates;Templates" `

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ Each script can be run from the command line or through the included GUI launche
 Extract plant names and images from a source PDF.
 
 ```bash
-python Static/Python/PDFScraper.py \
+python Static/Python_lite/PDFScraper.py \
     --in_pdf Templates/Plant\ Guide\ 2025\ Update.pdf \
     --out_csv Outputs/Plants_NeedLinks.csv \
     --img_dir Outputs/pdf_images \
@@ -49,7 +49,7 @@ python Static/Python/PDFScraper.py \
 Generate a styled PDF from your filled CSV and images.
 
 ```bash
-python Static/Python/GeneratePDF.py \
+python Static/Python_lite/GeneratePDF.py \
     --in_csv Outputs/Plants_Linked_Filled.csv \
     --out_pdf Outputs/Plant_Guide_EXPORT.pdf \
     --img_dir Outputs/pdf_images/jpeg \
@@ -61,7 +61,7 @@ python Static/Python/GeneratePDF.py \
 Export a formatted Excel workbook for easy filtering and review.
 
 ```bash
-python Static/Python/Excelify2.py \
+python Static/Python_lite/Excelify2.py \
     --in_csv Outputs/Plants_Linked_Filled.csv \
     --out_xlsx Outputs/Plants_Linked_Filled_Review.xlsx \
     --template_csv Templates/Plants_Linked_Filled_Master.csv
@@ -72,7 +72,7 @@ python Static/Python/Excelify2.py \
 Provides a simple GUI interface for the tools above:
 
 ```bash
-python Launcher.py
+python Launcher_lite.py
 ```
 
 ---
@@ -82,11 +82,11 @@ python Launcher.py
 If you'd like to build standalone executables using PyInstaller:
 
 ```bash
-pyinstaller --onefile --distpath helpers Static/Python/PDFScraper.py
-pyinstaller --onefile --distpath helpers Static/Python/GeneratePDF.py
-pyinstaller --onefile --distpath helpers Static/Python/Excelify2.py
+pyinstaller --onefile --distpath helpers Static/Python_lite/PDFScraper.py
+pyinstaller --onefile --distpath helpers Static/Python_lite/GeneratePDF.py
+pyinstaller --onefile --distpath helpers Static/Python_lite/Excelify2.py
 
-pyinstaller Launcher.py --onedir --noconfirm --windowed \
+pyinstaller Launcher_lite.py --onedir --noconfirm --windowed \
   --add-data "Static;Static" \
   --add-data "Templates;Templates" \
   --add-data "helpers;helpers" \
@@ -98,7 +98,7 @@ pyinstaller Launcher.py --onedir --noconfirm --windowed \
 ## Folder Layout
 
 ```
-├── Launcher.py
+├── Launcher_lite.py
 ├── Static/
 │   └── Python_lite/
 │   │    ├── PDFScraper.py


### PR DESCRIPTION
## Summary
- document `Launcher_lite.py` instead of `Launcher.py`
- point PyInstaller examples at `Static/Python_lite`
- update folder layout to match project structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847639e8cd08326af52b21b8fcad584