### PR TITLE
Fix bloom time month order

### DIFF
--- a/SampleTest/FillMissingData_Test.py
+++ b/SampleTest/FillMissingData_Test.py
@@ -354,7 +354,14 @@ def month_list(raw: str | None) -> str | None:
         a, b = MONTHS.index(rng[0][:3]), MONTHS.index(rng[1][:3])
         if a <= b:
             return ", ".join(MONTHS[a : b + 1])
-    return ", ".join({m[:3] for m in rng if m[:3] in MONTHS})
+
+    months = []
+    for m in rng:
+        abbr = m[:3]
+        if abbr in MONTHS and abbr not in months:
+            months.append(abbr)
+    months.sort(key=MONTHS.index)
+    return ", ".join(months)
 
 
 

--- a/Static/Python_full/FillMissingData.py
+++ b/Static/Python_full/FillMissingData.py
@@ -285,7 +285,14 @@ def month_list(raw: str | None) -> str | None:
         a, b = MONTHS.index(rng[0][:3]), MONTHS.index(rng[1][:3])
         if a <= b:
             return ", ".join(MONTHS[a : b + 1])
-    return ", ".join({m[:3] for m in rng if m[:3] in MONTHS})
+
+    months = []
+    for m in rng:
+        abbr = m[:3]
+        if abbr in MONTHS and abbr not in months:
+            months.append(abbr)
+    months.sort(key=MONTHS.index)
+    return ", ".join(months)
 
 
 


### PR DESCRIPTION
## Summary
- avoid unordered set for bloom months
- ensure months remain unique and sorted

## Testing
- `pytest -q`
- `python SampleTest/FillMissingData_Test.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b719b30c8326a7e01af8329afc8e