### PR TITLE
Handle unicode dashes in month range parser

### DIFF
--- a/SampleTest/FillMissingData_Test.py
+++ b/SampleTest/FillMissingData_Test.py
@@ -325,7 +325,9 @@ def month_list(raw: str | None) -> str | None:
     """
     if not raw:
         return None
-    s = raw.title().replace("Through", "to").replace("–", "-")
+    s = raw.title().replace("Through", "to")
+    for dash in ("\u2013", "\u2014"):
+        s = s.replace(dash, "-")
     s = re.sub(r"\bto\b", "-", s)
     s = re.sub(r"\s*-\s*", "-", s)
     rng = re.split(r"[\s,/]+", s)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -37,3 +37,5 @@ def test_month_list_range_handling():
     month_list = load_function("SampleTest/FillMissingData_Test.py", "month_list")
     month_list.__globals__["MONTHS"] = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec".split()
     assert month_list("Feb - Jul") == "Feb, Mar, Apr, May, Jun, Jul"
+    assert month_list("Apr – Jun") == "Apr, May, Jun"
+    assert month_list("Nov—Dec") == "Nov, Dec"


### PR DESCRIPTION
## Summary
- normalize en/em dashes in `month_list`
- cover spaced en-dash and em-dash cases in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c66f98a48326a77ce486479e71db