### PR TITLE
Add Bloom Info fallback parsing

### DIFF
--- a/tests/test_parse_wf.py
+++ b/tests/test_parse_wf.py
@@ -9,3 +9,17 @@ def test_parse_wf_native_habitat():
     data = mod.parse_wf(html)
     assert "Native Habitats" in data
     assert "Wet Meadow" in data["Native Habitats"]
+
+
+def test_parse_wf_bloom_info_fallback():
+    repo_root = Path(__file__).resolve().parents[1]
+    mod = load_module(repo_root / "SampleTest" / "FillMissingData_Test.py")
+    html = (
+        repo_root
+        / "SampleTest"
+        / "html_cache"
+        / "www_wildflower_org_plants_result_php_0ebcdfb760da.html"
+    ).read_text()
+    data = mod.parse_wf(html)
+    assert data.get("Bloom Color") == "Red, Pink, Yellow"
+    assert data.get("Bloom Time") == "Feb, Mar, Apr, May, Jun, Jul"


### PR DESCRIPTION
## Summary
- ensure Wildflower pages without a Plant Characteristics table still yield Bloom Color and Bloom Time
- test parse_wf for Bloom Information fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ce3b7c308326af3e7e582f003b48