### PR TITLE
Ensure pd.read_csv preserves literal NA

### DIFF
--- a/ReviewFiles/Excelify2_backup.py
+++ b/ReviewFiles/Excelify2_backup.py
@@ -96,7 +96,7 @@ df = (
     )
     .fillna("")
 )
-template_cols = list(pd.read_csv(TEMPLATE_CSV, nrows=0).columns)
+template_cols = list(pd.read_csv(TEMPLATE_CSV, nrows=0, keep_default_na=False).columns)
 df = df.reindex(columns=template_cols + [c for c in df.columns if c not in template_cols])
 
 # Normalise casing

--- a/ReviewFiles/SampleTest/SampleTestvManual.py
+++ b/ReviewFiles/SampleTest/SampleTestvManual.py
@@ -48,7 +48,7 @@ def load(path: Path) -> pd.DataFrame:
     if not path.exists():
         console.print(f"[red]ERROR:[/red] file not found → {path}")
         sys.exit(2)
-    return pd.read_csv(path, dtype=str).fillna("")
+    return pd.read_csv(path, dtype=str, keep_default_na=False).fillna("")
 
 
 def row_key(row: pd.Series) -> str:

--- a/Static/Python_full/FillMissingData.py
+++ b/Static/Python_full/FillMissingData.py
@@ -937,7 +937,7 @@ def fill_csv(in_csv: Path, out_csv: Path, master_csv: Path) -> None:
         "PN Link":  "Link: Pinelandsnursery.com",
     }, inplace=True)
 
-    template_cols = list(pd.read_csv(master_csv, nrows=0).columns)
+    template_cols = list(pd.read_csv(master_csv, nrows=0, keep_default_na=False).columns)
     for c in template_cols:
         if c not in df.columns:
             df[c] = ""

--- a/Static/Python_full/GeneratePDF.py
+++ b/Static/Python_full/GeneratePDF.py
@@ -87,8 +87,8 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
 
 # --- Load and Prepare Data ------------------------------------------------
-df = pd.read_csv(CSV_FILE, dtype=str).fillna("").replace("Needs Review", "")  # Read CSV, empty cells -> ""
-template_cols = list(pd.read_csv(TEMPLATE_CSV, nrows=0).columns)
+df = pd.read_csv(CSV_FILE, dtype=str, keep_default_na=False).fillna("").replace("Needs Review", "")  # Read CSV, empty cells -> ""
+template_cols = list(pd.read_csv(TEMPLATE_CSV, nrows=0, keep_default_na=False).columns)
 df = df.reindex(
     columns=template_cols + [c for c in df.columns if c not in template_cols]
 )

--- a/Static/Python_full/GetLinks.py
+++ b/Static/Python_full/GetLinks.py
@@ -105,7 +105,7 @@ NM_COL = "Link: Newmoonnursery.com"
 PN_COL = "Link: Pinelandsnursery.com"
 
 # --- Step 1: Load CSVs & prefill from master -----------------------------
-df = pd.read_csv(INPUT, dtype=str).fillna("")
+df = pd.read_csv(INPUT, dtype=str, keep_default_na=False).fillna("")
 
 rename_map = {
     "Link: Missouri Botanical Garden": MBG_COL,
@@ -132,7 +132,7 @@ reverse_map = {
 }
 
 try:
-    master = pd.read_csv(MASTER, dtype=str).fillna("")
+    master = pd.read_csv(MASTER, dtype=str, keep_default_na=False).fillna("")
     master.rename(
         columns={k: v for k, v in rename_map.items() if k in master.columns},
         inplace=True,
@@ -181,7 +181,7 @@ needs = df[
 if needs.empty:
     # Normalize any legacy column names before exporting
     df.rename(columns=reverse_map, inplace=True)
-    template_cols = list(pd.read_csv(MASTER, nrows=0).columns)
+    template_cols = list(pd.read_csv(MASTER, nrows=0, keep_default_na=False).columns)
     df = df.reindex(
         columns=template_cols + [c for c in df.columns if c not in template_cols]
     )
@@ -512,7 +512,7 @@ for i, row in needs.iterrows():
 # --- Save & exit --------------------------------------------------------
 driver.quit()
 df.rename(columns=reverse_map, inplace=True)
-template_cols = list(pd.read_csv(MASTER, nrows=0).columns)
+template_cols = list(pd.read_csv(MASTER, nrows=0, keep_default_na=False).columns)
 df = df.reindex(
     columns=template_cols + [c for c in df.columns if c not in template_cols]
 )

--- a/Static/Python_full/PDFScraper_depreciate.py
+++ b/Static/Python_full/PDFScraper_depreciate.py
@@ -101,9 +101,9 @@ def safe_print(*objs, **kw):
 
 # --- CSV Columns ---------------------------------------------------------
 MASTER_CSV = repo_path("Templates/Plants_Linked_Filled_Master.csv")
-template_cols = list(pd.read_csv(MASTER_CSV, nrows=0).columns)
+template_cols = list(pd.read_csv(MASTER_CSV, nrows=0, keep_default_na=False).columns)
 
-master_df = pd.read_csv(MASTER_CSV, dtype=str).fillna("")
+master_df = pd.read_csv(MASTER_CSV, dtype=str, keep_default_na=False).fillna("")
 master_idx = master_df.set_index("Botanical Name")
 
 COLUMNS = ["Page in PDF"] + template_cols


### PR DESCRIPTION
## Summary
- set `keep_default_na=False` everywhere `pd.read_csv` is used

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684dfbbe3f68832682c6331c8564daa7