### PR TITLE
Handle bold labels in UseXYZ tags

### DIFF
--- a/Static/Python_full/GeneratePDF.py
+++ b/Static/Python_full/GeneratePDF.py
@@ -410,9 +410,13 @@ class PlantPDF(FPDF):
                 usexyz = safe_text(row.get("UseXYZ", ""))
                 if usexyz:
                     tags = [t.strip() for t in usexyz.split("|") if t.strip()]
-                    self.set_font("Times", "", 12)
                     for i, tag in enumerate(tags):
-                        self.write(6, f"{tag}")
+                        head, body = (p.strip() for p in tag.split(":", 1)) if ":" in tag else (tag, "")
+                        self.set_font("Times", "B", 12)
+                        self.write(6, head)
+                        if body:
+                            self.set_font("Times", "", 12)
+                            self.write(6, f": {body}")
                         if i < len(tags) - 1:
                             self.write(6, "  |  ")
                     self.ln(6)


### PR DESCRIPTION
## Summary
- bold the label portion of `UseXYZ` tags in `GeneratePDF`

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ea37cc388326a987c1708ca95809