### PR TITLE
Fix duplicate Maintenance label

### DIFF
--- a/Static/Python_full/GeneratePDF.py
+++ b/Static/Python_full/GeneratePDF.py
@@ -446,8 +446,12 @@ class PlantPDF(FPDF):
                 # --- Detailed Maintenance and Issues ---
                 val = truncate_text(safe_text(row.get("WFMaintenance", "")), max_len, bot_name, "WFMaintenance")
                 if val:
+                    has_prefix = val.lower().startswith("maintenance:")
+                    if has_prefix:
+                        val = val[len("maintenance:"):].lstrip()
                     self.set_font("Times", "B", 12)
-                    self.write(6, "Maintenance: ")
+                    if not has_prefix:
+                        self.write(6, "Maintenance: ")
                     self.set_font("Times", "", 12)
                     self.multi_cell(0, 4, val)
 


### PR DESCRIPTION
## Summary
- remove `Maintenance:` prefix from `WFMaintenance` text when present
- avoid printing duplicate "Maintenance:" label in generated PDFs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850ea39aa6c832687115f5a8d084f73